### PR TITLE
deps: updates wazero to 1.0.0-pre.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/pims/prql-go
 
 go 1.19
 
-require github.com/tetratelabs/wazero v1.0.0-pre.5
+require github.com/tetratelabs/wazero v1.0.0-pre.8
 
 require github.com/segmentio/fasthash v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
 github.com/segmentio/fasthash v1.0.3 h1:EI9+KE1EwvMLBWwjpRDc+fEM+prwxDYbslddQGtrmhM=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/tetratelabs/wazero v1.0.0-pre.5 h1:ChZsQewsazFwF+NT6qAKPwnqqiOlf2MN0aah1dlD8Bk=
-github.com/tetratelabs/wazero v1.0.0-pre.5/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
+github.com/tetratelabs/wazero v1.0.0-pre.8 h1:Ir82PWj79WCppH+9ny73eGY2qv+oCnE3VwMY92cBSyI=
+github.com/tetratelabs/wazero v1.0.0-pre.8/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0-pre.8](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.8)

Signed-off-by: Edoardo Vacchi <evacchi@users.noreply.github.com>
