### PR TITLE
deps: updates wazero to 1.0.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/pims/prql-go
 
 go 1.19
 
-require github.com/tetratelabs/wazero v1.0.0-pre.8
+require github.com/tetratelabs/wazero v1.0.1
 
 require github.com/segmentio/fasthash v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
 github.com/segmentio/fasthash v1.0.3 h1:EI9+KE1EwvMLBWwjpRDc+fEM+prwxDYbslddQGtrmhM=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/tetratelabs/wazero v1.0.0-pre.8 h1:Ir82PWj79WCppH+9ny73eGY2qv+oCnE3VwMY92cBSyI=
-github.com/tetratelabs/wazero v1.0.0-pre.8/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
+github.com/tetratelabs/wazero v1.0.1 h1:xyWBoGyMjYekG3mEQ/W7xm9E05S89kJ/at696d/9yuc=
+github.com/tetratelabs/wazero v1.0.1/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.1](https://github.com/tetratelabs/wazero/releases/tag/v1.0.1).

On behalf of everyone in the community, I want to thank you for trying wazero before we became stable. We will not raise unsolicited pull requests anymore. That said, if any update gives you problems, please feel free to contact [us](https://wazero.io/community/) on slack or via a GitHub issue.

This PR also includes changes for [wazero](https://wazero.io/) [1.0.0-pre.9][1] and [1.0.0-rc.2][2]. Notably:

* Requires at least Go 1.8
* Renames `Runtime.InstantiateModuleFromBinary` to `Runtime.Instantiate`
* Integrates Go context to limit execution time.
* Full support to the WASI test suite and other third-party integration tests
* A number of optimizations to reduce compilation overhead

Finally, if you would like to share your work, feel free to update our [users page](https://github.com/tetratelabs/wazero/blob/main/site/content/community/users.md)!



[1]: https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.9
[2]: https://github.com/tetratelabs/wazero/releases/tag/1.0.0-rc.2

Signed-off-by: Edoardo Vacchi <evacchi@users.noreply.github.com>
